### PR TITLE
Fix request flags

### DIFF
--- a/py_src/gpiod/libgpiodcxx/__init__.py
+++ b/py_src/gpiod/libgpiodcxx/__init__.py
@@ -396,16 +396,6 @@ reqflag_mapping = {
 }
 
 
-def merge_and_map_flags(config_flags: int) -> int:
-    result = 0
-
-    for k, v in reqflag_mapping.items():
-        if config_flags & k:
-            result |= v
-
-    return result
-
-
 class line:
     # pylint: disable=function-redefined
     def __init__(
@@ -558,7 +548,11 @@ class line:
         conf = libgpiod.gpiod_line_request_config()
         conf.consumer = config.consumer
         conf.request_type = reqtype_mapping[config.request_type]
-        conf.flags = merge_and_map_flags(config.flags)
+        conf.flags = 0
+
+        for k, v in reqflag_mapping.items():
+            if config.flags & k:
+                conf.flags |= v
 
         rv = libgpiod.gpiod_line_request(_m_line, conf, default_val)
         if rv:

--- a/py_src/gpiod/libgpiodcxx/__init__.py
+++ b/py_src/gpiod/libgpiodcxx/__init__.py
@@ -395,6 +395,7 @@ reqflag_mapping = {
     line_request.FLAG_OPEN_SOURCE: libgpiod.GPIOD_LINE_REQUEST_FLAG_OPEN_SOURCE,
 }
 
+
 def merge_and_map_flags(config_flags: int) -> int:
     result = 0
 
@@ -403,6 +404,7 @@ def merge_and_map_flags(config_flags: int) -> int:
             result |= v
 
     return result
+
 
 class line:
     # pylint: disable=function-redefined

--- a/py_src/gpiod/libgpiodcxx/__init__.py
+++ b/py_src/gpiod/libgpiodcxx/__init__.py
@@ -395,6 +395,14 @@ reqflag_mapping = {
     line_request.FLAG_OPEN_SOURCE: libgpiod.GPIOD_LINE_REQUEST_FLAG_OPEN_SOURCE,
 }
 
+def merge_and_map_flags(config_flags: int) -> int:
+    result = 0
+
+    for k, v in reqflag_mapping.items():
+        if config_flags & k:
+            result |= v
+
+    return result
 
 class line:
     # pylint: disable=function-redefined
@@ -548,7 +556,7 @@ class line:
         conf = libgpiod.gpiod_line_request_config()
         conf.consumer = config.consumer
         conf.request_type = reqtype_mapping[config.request_type]
-        conf.flags = 0
+        conf.flags = merge_and_map_flags(config.flags)
 
         rv = libgpiod.gpiod_line_request(_m_line, conf, default_val)
         if rv:


### PR DESCRIPTION
The flags were always set to zero when creating line request. Thus it was impossible to configure active state to low.