### PR TITLE
Include py.typed in MANIFEST.in for compatibility with sdist and bdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include LICENSE.txt
 include README.md
 include CHANGELOG
+recursive-include py_src py.typed

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,3 @@ include_package_data = True
 
 [options.packages.find]
 where = py_src
-
-[options.package_data]
-gpiod = py.typed


### PR DESCRIPTION
Fixes #21 for sdist and bdist
```
(venv) jordan@enigma:~/src/python3-gpiod$ python setup.py sdist | grep typed
copying py_src/gpiod/py.typed -> gpiod-1.5.1/py_src/gpiod
(venv) jordan@enigma:~/src/python3-gpiod$ python setup.py bdist | grep typed
copying build/lib/gpiod/py.typed -> build/bdist.linux-x86_64/dumb/home/jordan/src/python3-gpiod/venv/lib/python3.8/site-packages/gpiod
```