### PR TITLE
libgpiod: fix error when opening symlinks to gpiochips

### DIFF
--- a/py_src/gpiod/libgpiod/__init__.py
+++ b/py_src/gpiod/libgpiod/__init__.py
@@ -33,6 +33,7 @@ from os import open as os_open
 from os import read as os_read
 from os import scandir
 from os.path import basename
+from os.path import realpath
 from select import POLLIN, POLLNVAL, POLLPRI
 from stat import S_ISCHR
 from typing import Iterator, List, Optional, Union
@@ -48,6 +49,9 @@ _LINE_REQUESTED_EVENTS = 2
 
 
 def _is_gpiochip_cdev(path: str) -> bool:
+    # Sanitize the path before performing checks on it
+    path = realpath(path)
+
     try:
         statbuf = lstat(path)
     except FileNotFoundError:


### PR DESCRIPTION
Function _is_gpiochip_cdev assumes the path provides is the actual character device file but it might be a symlink to one and still be valid.

Make sure to follow the links before performing the checks